### PR TITLE
`normalized_shape` usage in test_fused_ops.py is not aligned with PyTorch specification

### DIFF
--- a/pa1/tests/test_fused_ops.py
+++ b/pa1/tests/test_fused_ops.py
@@ -33,10 +33,10 @@ def test_matmul_layernorm_forward():
     x2 = ad.Variable("x2")
     
     # Create computation graphs for both fused and separate ops
-    fused_y = matmul_layernorm(x1, x2, normalized_shape=[3])
+    fused_y = matmul_layernorm(x1, x2, normalized_shape=[4])
     separate_y = ad.layernorm(
         ad.matmul(x1, x2),
-        normalized_shape=[3]
+        normalized_shape=[4]
     )
 
     # Test input values
@@ -57,10 +57,10 @@ def test_matmul_layernorm_backward():
     x2 = ad.Variable("x2")
     
     # Create computation graphs for both fused and separate ops
-    fused_y = matmul_layernorm(x1, x2, normalized_shape=[3])
+    fused_y = matmul_layernorm(x1, x2, normalized_shape=[4])
     separate_y = ad.layernorm(
         ad.matmul(x1, x2),
-        normalized_shape=[3]
+        normalized_shape=[4]
     )
     
     y_grad = ad.Variable("y_grad")


### PR DESCRIPTION
 > PyTorch: [this module will normalize over the last dimension which is expected to be of that specific size.]( https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html)
 
 
 ```
 import torch
x1_val = torch.tensor([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [5.0, 6.0, 7.0]])
x2_val = torch.tensor([[7.0, 8.0, 9.0, 10.0], [10.0, 11.0, 12.0, 13.0], [13.0, 14.0, 15.0, 16.0]])

torch.layer_norm(torch.matmul(x1_val, x2_val), normalized_shape=[3])
RuntimeError: Given normalized_shape=[3], expected input with shape [*, 3], but got input of size[3, 4]
```